### PR TITLE
Docs:拼写错误

### DIFF
--- a/docs/guide/event_data.md
+++ b/docs/guide/event_data.md
@@ -15,7 +15,7 @@ let cheated = ref(false)
 ::: code-group
 
 ```py [NoneBot Native]
-from nonebot.internal.adapter import Event
+from nonebot.adapters import Event
 from nonebot.adapters.onebot.v11 import MessageSegment
 
 matcher = on_command("来张涩图")
@@ -29,7 +29,7 @@ async def _(event: Event):
 ```
 
 ```py [NoneBot Alconna]
-from nonebot.internal.adapter import Event
+from nonebot.adapters import Event
 from nonebot_plugin_alconna import Command, UniMessage
 
 matcher = Command("来张涩图").build(use_cmd_start=True)

--- a/docs/guide/hello_hibiscus.md
+++ b/docs/guide/hello_hibiscus.md
@@ -7,7 +7,7 @@
 ```py
 # plugins/hello.py
 from nonebot import on_message
-from nonebot.adapter import Event
+from nonebot.adapters import Event
 
 hello_setu = on_message()
 
@@ -15,8 +15,8 @@ hello_setu = on_message()
 @hello_setu.handle()
 async def hello_handle(event: Event):
     message = event.get_message()
-    # await hello.send(f"不要说{message}，来张涩图")  # 普通发送，完成后继续后续流程
-    await hello.finish(f"不要说{message}，来张涩图")  # 最终发送，完成后停止整个流程
+    # await hello_setu.send(f"不要说{message}，来张涩图")  # 普通发送，完成后继续后续流程
+    await hello_setu.finish(f"不要说{message}，来张涩图")  # 最终发送，完成后停止整个流程
 ```
 
 <chat-window title="NoneBot Console">
@@ -34,7 +34,7 @@ async def hello_handle(event: Event):
 ```py{4,8}
 # plugins/hello.py
 from nonebot import on_message
-from nonebot.adapter import Event
+from nonebot.adapters import Event
 from nonebot.matcher import Matcher
 
 

--- a/docs/guide/message.md
+++ b/docs/guide/message.md
@@ -59,7 +59,7 @@ await UniMessage.image("xxx.jpg").finish()
 
 ```py [NoneBot Native]
 from nonebot import on_command
-from nonebot.adapter.onebot.v11 import Message, MessageSegment
+from nonebot.adapters.onebot.v11 import Message, MessageSegment
 
 matcher = on_command("来张涩图")
 
@@ -105,7 +105,7 @@ async def _():
 
 ```py [NoneBot Native]
 from nonebot import on_command
-from nonebot.adapter.onebot.v11 import Message, MessageSegment
+from nonebot.adapters.onebot.v11 import Message, MessageSegment
 
 matcher = on_command("来张涩图")
 


### PR DESCRIPTION
- [ ] `from nonebot.adapter import Event`拼写有误
应为`from nonebot.adapters import Event`

- [ ] `await hello.finish(f"不要说{message}，来张涩图")`变量名引用不一致​​
应为`await hello_setu.finish(...)`

- [ ] `from nonebot.internal.adapter import Event`是nonebot的内部实现，很少从这里导入，同时兼顾上文也使用`from nonebot.adapters import Event`导入，建议修改为`from nonebot.adapters import Event`